### PR TITLE
Remove ammotype reload

### DIFF
--- a/lua/cfc_entity_stubber/cw_attachment/am_flechetterounds.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_flechetterounds.lua
@@ -3,7 +3,13 @@ AddCSLuaFile()
 cfcEntityStubber.registerStub( function()
     local attachment = cfcEntityStubber.getAttachment( "am_flechetterounds" )
 
-    function attachment:attachFunc() end
-    function attachment:detachFunc() end
+    function attachment:attachFunc()
+        self.Shots = 20
+    end
+
+    function attachment:detachFunc()
+        self.Shots = self.Shots_Orig
+    end
+
     cfcEntityStubber.applyAttachmentChange( attachment )
 end )

--- a/lua/cfc_entity_stubber/cw_attachment/am_flechetterounds.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_flechetterounds.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local attachment = cfcEntityStubber.getAttachment( "am_flechetterounds" )
+
+    function attachment:attachFunc() end
+    function attachment:detachFunc() end
+    cfcEntityStubber.applyAttachmentChange( attachment )
+end )

--- a/lua/cfc_entity_stubber/cw_attachment/am_magnum.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_magnum.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local attachment = cfcEntityStubber.getAttachment( "am_magnum" )
+
+    function attachment:attachFunc() end
+    function attachment:detachFunc() end
+    cfcEntityStubber.applyAttachmentChange( attachment )
+end )

--- a/lua/cfc_entity_stubber/cw_attachment/am_matchgrade.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_matchgrade.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local attachment = cfcEntityStubber.getAttachment( "am_matchgrade" )
+
+    function attachment:attachFunc() end
+    function attachment:detachFunc() end
+    cfcEntityStubber.applyAttachmentChange( attachment )
+end )

--- a/lua/cfc_entity_stubber/cw_attachment/am_reducedpowderload.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_reducedpowderload.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+cfcEntityStubber.registerStub( function()
+    local attachment = cfcEntityStubber.getAttachment( "am_reducedpowderload" )
+
+    function attachment:attachFunc() end
+    function attachment:detachFunc() end
+    cfcEntityStubber.applyAttachmentChange( attachment )
+end )

--- a/lua/cfc_entity_stubber/cw_attachment/am_slugrounds.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_slugrounds.lua
@@ -7,7 +7,15 @@ cfcEntityStubber.registerStub( function()
         DamageMult = 7.5,
         AimSpreadMult = 1.3
     }
-    function attachment:attachFunc() end
-    function attachment:detachFunc() end
+    function attachment:attachFunc()
+        self.Shots = 1
+        self.ClumpSpread = nil
+    end
+
+    function attachment:detachFunc()
+        self.Shots = self.Shots_Orig
+        self.ClumpSpread = self.ClumpSpread_Orig
+    end
+
     cfcEntityStubber.applyAttachmentChange( attachment )
 end )

--- a/lua/cfc_entity_stubber/cw_attachment/am_slugrounds.lua
+++ b/lua/cfc_entity_stubber/cw_attachment/am_slugrounds.lua
@@ -7,6 +7,7 @@ cfcEntityStubber.registerStub( function()
         DamageMult = 7.5,
         AimSpreadMult = 1.3
     }
-
+    function attachment:attachFunc() end
+    function attachment:detachFunc() end
     cfcEntityStubber.applyAttachmentChange( attachment )
 end )


### PR DESCRIPTION
Tested locally, seems to work for all CW weapon packs. This small change has big effects, players will no longer have to reload when spawning every weapon they have a preset for. 

edit: This also seems to mitigate a major bug whereby players who reload shortly after spawning a weapon must fully reload their weapon twice before getting any ammo.

In theory this immediately makes CW thrice as usable.
