### PR TITLE
Add simple weapons

### DIFF
--- a/lua/cfc_entity_stubber/simple_weapons/basic_patches.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/basic_patches.lua
@@ -1,0 +1,49 @@
+AddCSLuaFile()
+
+-- Since a bunch of weapons are getting very little edits I'm going to use a helper function here
+local function applyBasicPatch(class, range, accuracy)
+    cfcEntityStubber.registerStub( function()
+        local weapon = cfcEntityStubber.getWeapon( class )
+
+        if range then
+            weapon.Primary.Range = range
+        end
+
+        if accuracy then
+            weapon.Primary.Accuracy = accuracy
+        end
+    end )
+end
+
+applyBasicPatch( "simple_hl2_357", 2000, 8 )
+applyBasicPatch( "simple_hl2_ar2", 1600 )
+applyBasicPatch( "simple_hl2_pistol", 1200 )
+-- applyBasicPatch( "simple_hl2_shotgun" )
+applyBasicPatch( "simple_hl2_smg1", 600 )
+
+applyBasicPatch( "simple_hl2e_arp", 1200 )
+
+applyBasicPatch( "simple_css_ak47", 2000 )
+applyBasicPatch( "simple_css_aug", 3400, 8 )
+applyBasicPatch( "simple_css_awp", 8000, 8 )
+applyBasicPatch( "simple_css_deagle", 2000, 8 )
+applyBasicPatch( "simple_css_elite", 1400 )
+applyBasicPatch( "simple_css_famas", 2000 )
+-- applyBasicPatch( "simple_css_fiveseven" )
+applyBasicPatch( "simple_css_g3sg1", 6000, 8)
+applyBasicPatch( "simple_css_galil", 2000 )
+applyBasicPatch( "simple_css_glock", 1500 )
+-- applyBasicPatch( "simple_css_m3" )
+applyBasicPatch( "simple_css_m4a1", 2400 )
+applyBasicPatch( "simple_css_m249", 1400 )
+applyBasicPatch( "simple_css_mac10", 1000 )
+applyBasicPatch( "simple_css_mp5", 1200 )
+applyBasicPatch( "simple_css_p90", 1000 )
+applyBasicPatch( "simple_css_p228", 2400 )
+applyBasicPatch( "simple_css_scout", 8000, 8 )
+applyBasicPatch( "simple_css_sg550", 6000, 8 )
+applyBasicPatch( "simple_css_sg552", 3200, 8 )
+applyBasicPatch( "simple_css_tmp", 1200 )
+applyBasicPatch( "simple_css_ump", 1800 )
+applyBasicPatch( "simple_css_usp", 2800 )
+-- applyBasicPatch( "simple_css_xm1014" )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_ent_hl2e_20mm.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_ent_hl2e_20mm.lua
@@ -3,7 +3,7 @@ AddCSLuaFile()
 -- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/entities/simple_ent_hl2e_20mm.lua
 
 cfcEntityStubber.registerStub( function()
-    local entity = cfcEntityStubber.getWeapon( "simple_ent_hl2e_20mm" )
+    local entity = scripted_ents.GetStored( "simple_ent_hl2e_20mm" )
 
     entity.Damage = 60
 end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_ent_hl2e_20mm.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_ent_hl2e_20mm.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/entities/simple_ent_hl2e_20mm.lua
+
+cfcEntityStubber.registerStub( function()
+    local entity = cfcEntityStubber.getWeapon( "simple_ent_hl2e_20mm" )
+
+    entity.Damage = 60
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_alyxgun.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_alyxgun.lua
@@ -1,0 +1,12 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_alyxgun.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_alyxgun" )
+
+    weapon.Primary.Range = 1500
+
+    weapon.Primary.Recoil.MinAng = Angle(0.6, -0.3, 0)
+    weapon.Primary.Recoil.MaxAng = Angle(0.7, 0.3, 0)
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_ar1.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_ar1.lua
@@ -1,0 +1,12 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_ar1.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_ar1" )
+
+    weapon.Primary.Range = 1000
+
+    weapon.Primary.Recoil.MinAng = Angle(0.6, -0.3, 0)
+    weapon.Primary.Recoil.MaxAng = Angle(0.7, 0.3, 0)
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_ar3.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_ar3.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_ar3.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_ar3" )
+
+    weapon.Primary.Range = 1200
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_ar3_sniper.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_ar3_sniper.lua
@@ -1,0 +1,12 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_ar3_sniper.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_ar3_sniper" )
+
+    weapon.Primary.Range = 4000
+    weapon.Primary.Accuracy = 8
+
+    weapon.Primary.UnscopedRange = 800
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_autogun.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_autogun.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_autogun.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_autogun" )
+
+    weapon.Primary.Damage = 60
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_crossbow_he.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_crossbow_he.lua
@@ -1,0 +1,9 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_crossbow_he.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_crossbow_he" )
+
+    weapon.Primary.Damage = 80
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_csniper.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_csniper.lua
@@ -1,0 +1,33 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_csniper.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_csniper" )
+    local base = baseclass.Get( "simple_base_scoped" )
+
+    weapon.Primary.Damage = 160
+
+    weapon.Primary.Range = 8000
+    weapon.Primary.Accuracy = 8
+
+    weapon.Primary.RangeModifier = 0.96
+
+    -- Don't allow the weapon to fire while unscoped
+    weapon.CanPrimaryFire = function( self )
+        if not base.CanPrimaryFire( self ) then
+            return false
+        end
+
+        if self:GetScopeIndex() == 0 then
+            self:EmitSound( "items/medshotno1.wav", 75, 100, 0.7, CHAN_STATIC )
+
+            self:SetNextFire( CurTime() + 0.2 )
+            self:ForceStopFire()
+
+            return false
+        end
+
+        return true
+    end
+end )

--- a/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_oicw.lua
+++ b/lua/cfc_entity_stubber/simple_weapons/simple_hl2e_oicw.lua
@@ -1,0 +1,13 @@
+AddCSLuaFile()
+
+-- https://github.com/TankNut/simple-weapons-hl2e/blob/master/lua/weapons/simple_hl2e_oicw.lua
+
+cfcEntityStubber.registerStub( function()
+    local weapon = cfcEntityStubber.getWeapon( "simple_hl2e_oicw" )
+
+    weapon.Primary.Damage = 26
+    weapon.Primary.Range = 1400
+
+    weapon.Primary.Recoil.MinAng = Angle(0.8, -0.4, 0)
+    weapon.Primary.Recoil.MaxAng = Angle(1, 0.4, 0)
+end )

--- a/lua/cfc_entity_stubber/stubbers/simple_weapons_stubber.lua
+++ b/lua/cfc_entity_stubber/stubbers/simple_weapons_stubber.lua
@@ -1,0 +1,2 @@
+AddCSLuaFile()
+cfcEntityStubber.registerStubber("simple_weapons")


### PR DESCRIPTION
Does a proper balance pass over most of the simple weapons base to make the weapons more viable compared to the likes of m9k.

**!Important!** `simple_weapons_range_mult` should be set back to `1` when this PR is merged as the value currently live on the server has been built into these changes. The reason this was done is because the range multiplier convar affects shotguns, whereas they are specifically excluded here.

### Changes

**General changes**
- Most non-shotgun weapons have had their range doubled
- Snipers and DMR's have had their accuracy doubled
- (Edit made to the base itself) Weapons can no longer reload in between shots

**Specific changes**
- Alyx Gun
   - Sideways recoil decreased
- AR1
   - Sideways recoil decreased
- AR3 DMR
   - Unscoped range increased (200 -> 800)
- Autogun
   - Damage increased (40 -> 60)
- HE Crossbow
   - Damage decreased (120 -> 80)
- Combine Sniper
   - Damage increased (120 -> 160)
   - Damage dropoff increased
   - **Can no longer be fired unscoped**
- OICW
   - Damage increased (20 -> 26)
   - Sideways recoil decreased
   - Grenade damage increased (40 -> 60)