### PR TITLE
Nerf CW bullet ACF damage multipliers

### DIFF
--- a/lua/cfc_entity_stubber/cw/cw_deagle.lua
+++ b/lua/cfc_entity_stubber/cw/cw_deagle.lua
@@ -9,7 +9,6 @@ cfcEntityStubber.registerStub( function()
     weapon.VelocitySensitivity = 0
     weapon.ReloadSpeed = 1.45
     weapon.Damage = 75
-    weapon.ACF_DamageMult = 10
     weapon.DeployTime = 0
     weapon.HolsterTime = 0
     weapon.SpreadPerShot = 0.0001

--- a/lua/cfc_entity_stubber/cw/cw_g4p_awm.lua
+++ b/lua/cfc_entity_stubber/cw/cw_g4p_awm.lua
@@ -4,7 +4,6 @@ cfcEntityStubber.registerStub( function()
     local weapon = cfcEntityStubber.getWeapon( "cw_g4p_awm" )
     weapon.Recoil = 15
     weapon.Damage = 105
-    weapon.ACF_DamageMult = 10
     weapon.AimBreathingEnabled = false
     weapon.AimSpread = 0.00001
     weapon.DeployTime = 0

--- a/lua/cfc_entity_stubber/cw/cw_g4p_m98b.lua
+++ b/lua/cfc_entity_stubber/cw/cw_g4p_m98b.lua
@@ -3,7 +3,6 @@ AddCSLuaFile()
 cfcEntityStubber.registerStub( function()
     local weapon = cfcEntityStubber.getWeapon( "cw_g4p_m98b" )
     weapon.Damage = 110
-    weapon.ACF_DamageMult = 13
     weapon.AimBreathingEnabled = false
     weapon.AimSpread = 0.00001
     weapon.DeployTime = 0

--- a/lua/cfc_entity_stubber/cw/cw_g4p_mp412_rex.lua
+++ b/lua/cfc_entity_stubber/cw/cw_g4p_mp412_rex.lua
@@ -14,7 +14,6 @@ cfcEntityStubber.registerStub( function()
     weapon.HolsterUnderwater = false
     weapon.FireDelay = 0.595
     weapon.RecoilToSpread = 0
-    weapon.ACF_DamageMult = 10
     weapon.DeployTime = 0
     weapon.HolsterTime = 0
     weapon.NoRicochet = {[MAT_FLESH] = true, [MAT_ANTLION] = false, [MAT_BLOODYFLESH] = false, [MAT_DIRT] = false, [MAT_SAND] = false, [MAT_GLASS] = false, [MAT_ALIENFLESH] = false, [MAT_GRASS] = false}

--- a/lua/cfc_entity_stubber/cw/cw_jng90.lua
+++ b/lua/cfc_entity_stubber/cw/cw_jng90.lua
@@ -3,7 +3,6 @@ AddCSLuaFile()
 cfcEntityStubber.registerStub( function()
     local weapon = cfcEntityStubber.getWeapon( "cw_jng90" )
     weapon.Damage = 120
-    weapon.ACF_DamageMult = 13
     weapon.AimSpread = 0.00001
     weapon.VelocitySensitivity = 1
     weapon.DeployTime = 0

--- a/lua/cfc_entity_stubber/cw/cw_l115.lua
+++ b/lua/cfc_entity_stubber/cw/cw_l115.lua
@@ -3,7 +3,6 @@ AddCSLuaFile()
 cfcEntityStubber.registerStub( function()
     local weapon = cfcEntityStubber.getWeapon( "cw_l115" )
     weapon.Damage = 125
-    weapon.ACF_DamageMult = 10
     weapon.HipSpread = 0.03
     weapon.AimSpread = 0.00001
     weapon.AimBreathingEnabled = false

--- a/lua/cfc_entity_stubber/cw/cw_m249_official.lua
+++ b/lua/cfc_entity_stubber/cw/cw_m249_official.lua
@@ -11,5 +11,4 @@ cfcEntityStubber.registerStub( function()
     weapon.MaxSpreadInc = 0.02
     weapon.Recoil = 1.7
     weapon.Damage = 37
-    weapon.ACF_DamageMult = 7
 end )

--- a/lua/cfc_entity_stubber/cw/cw_m249_official.lua
+++ b/lua/cfc_entity_stubber/cw/cw_m249_official.lua
@@ -11,4 +11,5 @@ cfcEntityStubber.registerStub( function()
     weapon.MaxSpreadInc = 0.02
     weapon.Recoil = 1.7
     weapon.Damage = 37
+    weapon.ACF_DamageMult = 3
 end )

--- a/lua/cfc_entity_stubber/cw/cw_m3super90.lua
+++ b/lua/cfc_entity_stubber/cw/cw_m3super90.lua
@@ -7,7 +7,7 @@ cfcEntityStubber.registerStub( function()
     weapon.HipSpread = 0.06
     weapon.AimSpread = 0.025
     weapon.ClumpSpread = 0.04
-    weapon.recoil = 4
+    weapon.Recoil = 4
     weapon.FireDelay = 0.8
     weapon.DeployTime = 0
     weapon.HolsterTime = 0

--- a/lua/cfc_entity_stubber/cw/cw_ragingbull.lua
+++ b/lua/cfc_entity_stubber/cw/cw_ragingbull.lua
@@ -9,7 +9,6 @@ cfcEntityStubber.registerStub( function()
     weapon.ReloadSpeed = 1.15
     weapon.SpreadPerShot = 0.0001
     weapon.Damage = 70
-    weapon.ACF_DamageMult = 6
     weapon.DeployTime = 0
     weapon.HolsterTime = 0
     weapon.SprintingEnabled = false

--- a/lua/cfc_entity_stubber/cw/cw_shorty.lua
+++ b/lua/cfc_entity_stubber/cw/cw_shorty.lua
@@ -4,7 +4,7 @@ cfcEntityStubber.registerStub( function()
     local weapon = cfcEntityStubber.getWeapon( "cw_shorty" )
     weapon.VelocitySensitivity = 0
     weapon.Recoil = 6
-    weapon.damage = 12
+    weapon.Damage = 12
     weapon.HipSpread = 0.06
     weapon.AimSpread = 0.03
     weapon.DeployTime = 0

--- a/lua/cfc_entity_stubber/cw/cw_sv98.lua
+++ b/lua/cfc_entity_stubber/cw/cw_sv98.lua
@@ -7,7 +7,6 @@ cfcEntityStubber.registerStub( function()
     weapon.AimBreathingEnabled = false
     weapon.AimSpread = 0.00001
     weapon.Damage = 110
-    weapon.ACF_DamageMult = 10
     weapon.DeployTime = 0
     weapon.HolsterTime = 0
 end )

--- a/lua/cfc_entity_stubber/cw/cw_trg42.lua
+++ b/lua/cfc_entity_stubber/cw/cw_trg42.lua
@@ -3,7 +3,6 @@ AddCSLuaFile()
 cfcEntityStubber.registerStub( function()
     local weapon = cfcEntityStubber.getWeapon( "cw_trg42" )
     weapon.AimSpread = 0.0001
-    weapon.ACF_DamageMult = 13
     weapon.DeployTime = 0
     weapon.HolsterTime = 0
     weapon.VelocitySensitivity = 1


### PR DESCRIPTION
all ACF damage multipliers on seemingly-random CW guns have been removed, except the M249 which has been nerfed from 7x -> 3x, as per TwoLemons' and StrawWagen's request. 

also, I noticed there were a few capitalization errors on the Shorty and the M3 Super 90, those have been fixed as well.